### PR TITLE
ci: stabilize native builds and Flutter beta coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     name: Format & Analyze (${{ matrix.flutter-channel }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,11 +26,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-format-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
@@ -40,7 +42,8 @@ jobs:
   build-android:
     name: Build Android (${{ matrix.flutter-channel }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +70,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-android-:hash:'
 
@@ -80,7 +84,7 @@ jobs:
           restore-keys: gradle-${{ runner.os }}-
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Build APK (debug)
         run: flutter build apk --debug
@@ -88,7 +92,8 @@ jobs:
   build-ios:
     name: Build iOS (${{ matrix.flutter-channel }})
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -102,6 +107,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-ios-:hash:'
 
@@ -112,15 +118,8 @@ jobs:
           key: pods-ios-${{ hashFiles('ios/Podfile.lock', 'pubspec.lock') }}
           restore-keys: pods-ios-
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-ios-ci-${{ matrix.flutter-channel }}-xcode26.2-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-ios-ci-${{ matrix.flutter-channel }}-xcode26.2-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Install iOS pods
         working-directory: ios
@@ -144,7 +143,8 @@ jobs:
   build-macos:
     name: Build macOS (${{ matrix.flutter-channel }})
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,6 +155,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-macos-:hash:'
 
@@ -166,7 +167,7 @@ jobs:
           restore-keys: pods-macos-
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Install macOS pods
         working-directory: macos
@@ -184,7 +185,8 @@ jobs:
   build-linux:
     name: Build Linux (${{ matrix.flutter-channel }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -200,18 +202,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-linux-:hash:'
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-linux-ci-${{ matrix.flutter-channel }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-linux-ci-${{ matrix.flutter-channel }}-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prefetch mimalloc tarball
         uses: ./.github/actions/prefetch-mimalloc
@@ -233,7 +229,8 @@ jobs:
   build-windows:
     name: Build Windows (${{ matrix.flutter-channel }})
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -244,18 +241,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-windows-:hash:'
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-windows-ci-${{ matrix.flutter-channel }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-windows-ci-${{ matrix.flutter-channel }}-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Build Windows
         run: flutter build windows --debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,9 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-format-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        # Beta pins framework packages independently of stable. Preserve the
+        # committed lock exactly on stable; let beta resolve only SDK deltas.
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
@@ -84,7 +86,7 @@ jobs:
           restore-keys: gradle-${{ runner.os }}-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Build APK (debug)
         run: flutter build apk --debug
@@ -119,7 +121,7 @@ jobs:
           restore-keys: pods-ios-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Install iOS pods
         working-directory: ios
@@ -167,7 +169,7 @@ jobs:
           restore-keys: pods-macos-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Install macOS pods
         working-directory: macos
@@ -207,7 +209,7 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-linux-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Prefetch mimalloc tarball
         uses: ./.github/actions/prefetch-mimalloc
@@ -246,7 +248,7 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-ci-windows-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Build Windows
         run: flutter build windows --debug

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -97,7 +97,7 @@ jobs:
     name: Build Windows Installer
     needs: prepare
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -109,17 +109,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.44.8
           cache: true
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-windows-release-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-windows-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Build Windows release
         run: flutter build windows --release --build-name=${{ needs.prepare.outputs.version }} --build-number=${{ needs.prepare.outputs.build_number }}
@@ -178,17 +172,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.44.8
           cache: true
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-linux-release-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-linux-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prefetch mimalloc tarball
         uses: ./.github/actions/prefetch-mimalloc

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -47,10 +47,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.44.8
           cache: true
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
@@ -73,6 +74,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ inputs.flutter_channel }}
+          flutter-version: ${{ inputs.flutter_channel == 'stable' && '3.44.8' || '' }}
           cache: true
 
       - name: Cache CocoaPods
@@ -83,7 +85,7 @@ jobs:
           restore-keys: pods-macos-
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Install macOS pods
         working-directory: macos
@@ -115,6 +117,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ inputs.flutter_channel }}
+          flutter-version: ${{ inputs.flutter_channel == 'stable' && '3.44.8' || '' }}
           cache: true
 
       - name: Cache CocoaPods
@@ -124,15 +127,8 @@ jobs:
           key: pods-ios-${{ hashFiles('ios/Podfile.lock', 'pubspec.lock') }}
           restore-keys: pods-ios-
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-ios-${{ inputs.flutter_channel }}-xcode26.2-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-ios-${{ inputs.flutter_channel }}-xcode26.2-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Install iOS pods
         working-directory: ios
@@ -212,6 +208,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ inputs.flutter_channel }}
+          flutter-version: ${{ inputs.flutter_channel == 'stable' && '3.44.8' || '' }}
           cache: true
 
       - name: Cache Gradle
@@ -224,7 +221,7 @@ jobs:
           restore-keys: gradle-${{ runner.os }}-
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prewarm Android build
         run: flutter build apk --debug
@@ -264,17 +261,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ inputs.flutter_channel }}
+          flutter-version: ${{ inputs.flutter_channel == 'stable' && '3.44.8' || '' }}
           cache: true
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-linux-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-linux-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prefetch mimalloc tarball
         uses: ./.github/actions/prefetch-mimalloc
@@ -299,17 +290,11 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ inputs.flutter_channel }}
+          flutter-version: ${{ inputs.flutter_channel == 'stable' && '3.44.8' || '' }}
           cache: true
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-windows-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-windows-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prewarm Windows build
         run: flutter build windows --debug

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -85,7 +85,9 @@ jobs:
           restore-keys: pods-macos-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        # Stable must reproduce pubspec.lock. Moving beta channels may replace
+        # Flutter SDK-pinned packages that cannot share stable's exact lock.
+        run: flutter pub get ${{ inputs.flutter_channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Install macOS pods
         working-directory: macos
@@ -128,7 +130,7 @@ jobs:
           restore-keys: pods-ios-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ inputs.flutter_channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Install iOS pods
         working-directory: ios
@@ -221,7 +223,7 @@ jobs:
           restore-keys: gradle-${{ runner.os }}-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ inputs.flutter_channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Prewarm Android build
         run: flutter build apk --debug
@@ -265,7 +267,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ inputs.flutter_channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Prefetch mimalloc tarball
         uses: ./.github/actions/prefetch-mimalloc
@@ -294,7 +296,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ inputs.flutter_channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Prewarm Windows build
         run: flutter build windows --debug

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,7 @@ jobs:
     name: Unit Tests (${{ matrix.flutter-channel }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,11 +26,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-unit-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run unit tests with coverage
         run: flutter test --coverage
@@ -48,6 +50,7 @@ jobs:
     name: Integration macOS ${{ matrix.group }} (${{ matrix.flutter-channel }})
     runs-on: macos-15
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +62,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-macos-${{ matrix.group }}-:hash:'
 
@@ -70,7 +74,7 @@ jobs:
           restore-keys: pods-macos-
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Install macOS pods
         working-directory: macos
@@ -93,6 +97,7 @@ jobs:
     name: Integration iOS (${{ matrix.flutter-channel }})
     runs-on: macos-15
     timeout-minutes: 120
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +111,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-ios-:hash:'
 
@@ -116,16 +122,8 @@ jobs:
           key: pods-ios-${{ hashFiles('ios/Podfile.lock', 'pubspec.lock') }}
           restore-keys: pods-ios-
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        continue-on-error: true
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-ios-tests-${{ matrix.flutter-channel }}-xcode26.2-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-ios-tests-${{ matrix.flutter-channel }}-xcode26.2-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Install iOS pods
         working-directory: ios
@@ -193,6 +191,7 @@ jobs:
     name: Integration Android (${{ matrix.flutter-channel }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -219,6 +218,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-android-:hash:'
 
@@ -232,7 +232,7 @@ jobs:
           restore-keys: gradle-${{ runner.os }}-
 
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prewarm Android build
         run: flutter build apk --debug
@@ -265,6 +265,7 @@ jobs:
     name: Integration Linux ${{ matrix.group }} (${{ matrix.flutter-channel }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -281,19 +282,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-linux-${{ matrix.group }}-:hash:'
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        continue-on-error: true
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-linux-tests-${{ matrix.flutter-channel }}-${{ matrix.group }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-linux-tests-${{ matrix.flutter-channel }}-${{ matrix.group }}-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prefetch mimalloc tarball
         uses: ./.github/actions/prefetch-mimalloc
@@ -311,6 +305,7 @@ jobs:
     name: Integration Windows ${{ matrix.group }} (${{ matrix.flutter-channel }})
     runs-on: windows-latest
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.flutter-channel == 'beta' }}
     strategy:
       fail-fast: false
       matrix:
@@ -322,19 +317,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
+          flutter-version: ${{ matrix.flutter-channel == 'stable' && '3.44.8' || '' }}
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-windows-${{ matrix.group }}-:hash:'
 
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        continue-on-error: true
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-windows-tests-${{ matrix.flutter-channel }}-${{ matrix.group }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: opencv-native-windows-tests-${{ matrix.flutter-channel }}-${{ matrix.group }}-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Prewarm Windows build
         run: flutter build windows --debug

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,9 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-unit-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        # Beta pins framework packages independently of stable. Preserve the
+        # committed lock exactly on stable; let beta resolve only SDK deltas.
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Run unit tests with coverage
         run: flutter test --coverage
@@ -74,7 +76,7 @@ jobs:
           restore-keys: pods-macos-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Install macOS pods
         working-directory: macos
@@ -123,7 +125,7 @@ jobs:
           restore-keys: pods-ios-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Install iOS pods
         working-directory: ios
@@ -232,7 +234,7 @@ jobs:
           restore-keys: gradle-${{ runner.os }}-
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Prewarm Android build
         run: flutter build apk --debug
@@ -287,7 +289,7 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-linux-${{ matrix.group }}-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Prefetch mimalloc tarball
         uses: ./.github/actions/prefetch-mimalloc
@@ -322,7 +324,7 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-tests-windows-${{ matrix.group }}-:hash:'
 
       - name: Install dependencies
-        run: flutter pub get --enforce-lockfile
+        run: flutter pub get ${{ matrix.flutter-channel == 'stable' && '--enforce-lockfile' || '' }}
 
       - name: Prewarm Windows build
         run: flutter build windows --debug

--- a/.github/workflows/windows-db-smoke.yml
+++ b/.github/workflows/windows-db-smoke.yml
@@ -5,12 +5,19 @@ name: Windows DB smoke
 # via Dart build hooks; Windows is the only shipped platform with no system
 # SQLite fallback, so this is the one that must be verified.
 #
-# Runs on demand (workflow_dispatch) and on pushes to the perf branch that touch
-# the SQLite stack or this workflow. Not wired into the default CI.
+# Runs on demand and whenever a pull request or main-branch push changes the
+# SQLite dependency stack or this workflow.
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - pubspec.yaml
+      - pubspec.lock
+      - integration_test/windows_db_smoke_test.dart
+      - .github/workflows/windows-db-smoke.yml
   push:
-    branches: [perf/stabilize-micro-2]
+    branches: [main]
     paths:
       - pubspec.yaml
       - pubspec.lock
@@ -25,32 +32,19 @@ jobs:
   smoke:
     name: Windows sqlite3 DB round-trip
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.44.8
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-windows-db-smoke-:hash:'
 
-      # Reuse the opencv_dart native-asset build cache from the main test
-      # workflow so we don't recompile OpenCV from scratch.
-      - name: Cache opencv_dart native build
-        uses: actions/cache@v5
-        continue-on-error: true
-        with:
-          path: .dart_tool/hooks_runner/shared
-          key: opencv-native-windows-db-smoke-${{ hashFiles('pubspec.lock') }}
-          restore-keys: |
-            opencv-native-windows-db-smoke-
-            opencv-native-windows-tests-stable-fast-
-            opencv-native-windows-tests-stable-
-            opencv-native-windows-
-
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Assert sqlite3_flutter_libs is absent, sqlite3 present
         shell: bash

--- a/lib/utils/camera_utils.dart
+++ b/lib/utils/camera_utils.dart
@@ -266,16 +266,22 @@ class CameraUtils {
           await DirUtils.createDirectoryIfNotExists(thumbnailPath);
 
           String orientation;
-          if (captureThumbnailBytes != null &&
-              captureWidth != null &&
-              captureHeight != null) {
+          // These values are written before entering the async mutex callback.
+          // Snapshot them here so their null checks remain valid across awaits
+          // on every supported Dart analyzer.
+          final preparedThumbnailBytes = captureThumbnailBytes;
+          final preparedWidth = captureWidth;
+          final preparedHeight = captureHeight;
+          if (preparedThumbnailBytes != null &&
+              preparedWidth != null &&
+              preparedHeight != null) {
             // Thumbnail already created in isolate during rotation/mirroring,
             // write bytes directly, skip disk round-trip through
             // FastThumbnail.
-            await File(thumbnailPath).writeAsBytes(captureThumbnailBytes);
-            orientation = captureHeight > captureWidth
+            await File(thumbnailPath).writeAsBytes(preparedThumbnailBytes);
+            orientation = preparedHeight > preparedWidth
                 ? "portrait"
-                : captureHeight < captureWidth
+                : preparedHeight < preparedWidth
                     ? "landscape"
                     : "square";
           } else {
@@ -379,9 +385,12 @@ class CameraUtils {
           return false;
         }
 
+        // importProcessingOutput is assigned before entering this async
+        // callback. A final local keeps the validation sound across awaits.
+        final processingOutput = importProcessingOutput;
         if (bytes == null ||
-            importProcessingOutput == null ||
-            !importProcessingOutput.success) {
+            processingOutput == null ||
+            !processingOutput.success) {
           return false;
         }
 
@@ -456,14 +465,13 @@ class CameraUtils {
         sourceFilename ??= path.basename(originalFilePath ?? imgPath);
 
         // Write processed image if rotation/mirroring was applied
-        if (importProcessingOutput.processedBytes != null) {
-          await File(
-            imgPath,
-          ).writeAsBytes(importProcessingOutput.processedBytes!);
+        final processedBytes = processingOutput.processedBytes;
+        if (processedBytes != null) {
+          await File(imgPath).writeAsBytes(processedBytes);
         }
 
-        int importedImageWidth = importProcessingOutput.width;
-        int importedImageHeight = importProcessingOutput.height;
+        int importedImageWidth = processingOutput.width;
+        int importedImageHeight = processingOutput.height;
 
         String orientation = importedImageHeight > importedImageWidth
             ? "portrait"
@@ -495,12 +503,11 @@ class CameraUtils {
         await DirUtils.createDirectoryIfNotExists(thumbnailPath);
 
         // Write thumbnail (already created in isolate)
-        if (importProcessingOutput.thumbnailBytes == null) {
+        final thumbnailBytes = processingOutput.thumbnailBytes;
+        if (thumbnailBytes == null) {
           return false;
         }
-        await File(
-          thumbnailPath,
-        ).writeAsBytes(importProcessingOutput.thumbnailBytes!);
+        await File(thumbnailPath).writeAsBytes(thumbnailBytes);
 
         final linkedPlacement = await _maybePlaceSourceInLinkedFolder(
           projectId: projectId,


### PR DESCRIPTION
## Purpose

Make native CI deterministic before recertifying the dependency update branch.

## Changes

- snapshot nullable photo/import values so current Flutter beta compiles safely across awaits
- pin stable jobs to Flutter 3.44.8 while keeping moving beta jobs advisory
- enforce the committed lockfile on stable; allow beta to resolve only Flutter SDK-pinned package deltas
- remove cross-run `.dart_tool/hooks_runner/shared` caches that mixed incompatible native hook state
- wire the Windows sqlite smoke test into relevant pull requests and `main`
- give cold native builds realistic timeouts

## Local validation

- actionlint 1.7.12
- Flutter analyzer: clean
- 1,969 unit tests passed
- cold Android debug APK build passed
- iOS debug device build without signing passed
- macOS debug app build passed
- macOS desktop-fast: 228 passed
- macOS desktop-video: 44 passed, 33 intentional platform-specific skips

## CI validation

Every actual stable and beta job passed on a cold native-hook workspace:

- formatting and analysis
- unit tests
- Android, iOS, macOS, Linux, and Windows debug builds
- Android and iOS integration suites
- macOS, Linux, and Windows fast and video integration suites
- Windows sqlite3 database round-trip smoke test

Beta remains advisory by policy because it is a moving upstream toolchain, but this head passed beta in full.