### PR TITLE
fix(packaging): address package smoke failures

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -537,12 +537,14 @@ jobs:
           flatpak install --user -y --noninteractive "$FLATPAK_FILE"
 
           flatpak info --user com.hugocornellier.agelapse
-          flatpak run --command=sh com.hugocornellier.agelapse -c \
-            'test -x /app/agelapse &&
-             test -x /app/bin/agelapse &&
-             test -d /app/data/flutter_assets &&
-             test -x /app/lib/ffmpeg/bin/ffmpeg &&
-             test -f /app/share/applications/com.hugocornellier.agelapse.desktop'
+          flatpak run --command=sh com.hugocornellier.agelapse -euxc \
+            'test -x /app/agelapse
+             test -x /app/bin/agelapse
+             test -d /app/data/flutter_assets
+             test -d /app/lib/ffmpeg
+             test -f /app/share/applications/com.hugocornellier.agelapse.desktop
+             command -v ffmpeg
+             ffmpeg -hide_banner -version'
 
           set +e
           timeout --signal=TERM --kill-after=10s 20s \

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -18,6 +18,9 @@ icon: "linux/packaging/deb/agelapse.png"
 
 dependencies:
   - ffmpeg
+  - libgtk-3-0 | libgtk-3-0t64
+  - libgstreamer1.0-0
+  - libgstreamer-plugins-base1.0-0
   - libmpv2 | libmpv1
   - libturbojpeg | libturbojpeg0
 


### PR DESCRIPTION
## Summary

- declare the GTK and GStreamer runtime dependencies required by the Debian package
- validate the Flatpak codec extension directory and runtime FFmpeg command
- make Flatpak structural failures identify the exact command/path

## Evidence

Desktop Release run 30217064802 proved:

- Windows installer install/start/uninstall passed
- Linux bundle dependency/startup passed
- Debian package lacked `libgstapp-1.0.so.0` and `libgstvideo-1.0.so.0`
- Flatpak installed successfully but the smoke check incorrectly expected the codec extension to ship `/app/lib/ffmpeg/bin/ffmpeg`
- publish was skipped and no draft release was created

## Validation

- `git diff --check`
- Ruby YAML parser
- `actionlint` 1.7.12

