### PR TITLE
Upgrade cat_detection and dog_detection to 2.0.0

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -537,12 +537,14 @@ jobs:
           flatpak install --user -y --noninteractive "$FLATPAK_FILE"
 
           flatpak info --user com.hugocornellier.agelapse
-          flatpak run --command=sh com.hugocornellier.agelapse -c \
-            'test -x /app/agelapse &&
-             test -x /app/bin/agelapse &&
-             test -d /app/data/flutter_assets &&
-             test -x /app/lib/ffmpeg/bin/ffmpeg &&
-             test -f /app/share/applications/com.hugocornellier.agelapse.desktop'
+          flatpak run --command=sh com.hugocornellier.agelapse -euxc \
+            'test -x /app/agelapse
+             test -x /app/bin/agelapse
+             test -d /app/data/flutter_assets
+             test -d /app/lib/ffmpeg
+             test -f /app/share/applications/com.hugocornellier.agelapse.desktop
+             command -v ffmpeg
+             ffmpeg -hide_banner -version'
 
           set +e
           timeout --signal=TERM --kill-after=10s 20s \

--- a/lib/utils/stabilizer_utils/stabilizer_utils.dart
+++ b/lib/utils/stabilizer_utils/stabilizer_utils.dart
@@ -140,40 +140,48 @@ class StabUtils {
   // Cat Detection
   // ============================================================
 
-  static cat.CatDetectorIsolate? _catDetectorIsolate;
+  static cat.CatDetector? _catDetector;
   static final AsyncMutex _catDetectorMutex = AsyncMutex();
 
   static Future<void> _ensureCatDetector() async {
-    _catDetectorIsolate = await _ensureDetector<cat.CatDetectorIsolate>(
-      _catDetectorIsolate,
+    _catDetector = await _ensureDetector<cat.CatDetector>(
+      _catDetector,
       (d) => d.isReady,
-      () => cat.CatDetectorIsolate.spawn(mode: cat.CatDetectionMode.full),
+      () async {
+        final detector = cat.CatDetector(mode: cat.CatDetectionMode.full);
+        await detector.initialize();
+        return detector;
+      },
     );
   }
 
   static Future<void> disposeCatDetector() async {
-    await _catDetectorIsolate?.dispose();
-    _catDetectorIsolate = null;
+    await _catDetector?.dispose();
+    _catDetector = null;
   }
 
   // ============================================================
   // Dog Detection
   // ============================================================
 
-  static dog.DogDetectorIsolate? _dogDetectorIsolate;
+  static dog.DogDetector? _dogDetector;
   static final AsyncMutex _dogDetectorMutex = AsyncMutex();
 
   static Future<void> _ensureDogDetector() async {
-    _dogDetectorIsolate = await _ensureDetector<dog.DogDetectorIsolate>(
-      _dogDetectorIsolate,
+    _dogDetector = await _ensureDetector<dog.DogDetector>(
+      _dogDetector,
       (d) => d.isReady,
-      () => dog.DogDetectorIsolate.spawn(mode: dog.DogDetectionMode.full),
+      () async {
+        final detector = dog.DogDetector(mode: dog.DogDetectionMode.full);
+        await detector.initialize();
+        return detector;
+      },
     );
   }
 
   static Future<void> disposeDogDetector() async {
-    await _dogDetectorIsolate?.dispose();
-    _dogDetectorIsolate = null;
+    await _dogDetector?.dispose();
+    _dogDetector = null;
   }
 
   /// Validates PNG bytes by decoding and checking dimensions.
@@ -756,9 +764,9 @@ class StabUtils {
     bytes,
     _catDetectorMutex,
     _ensureCatDetector,
-    (b) => _catDetectorIsolate!.detectCats(b),
+    (b) => _catDetector!.detect(b),
     _convertCatFaces,
-    () => _catDetectorIsolate = null,
+    () => _catDetector = null,
     'cat',
     filterByFaceSize: filterByFaceSize,
     imageWidth: imageWidth,
@@ -795,9 +803,9 @@ class StabUtils {
     bytes,
     _dogDetectorMutex,
     _ensureDogDetector,
-    (b) => _dogDetectorIsolate!.detectDogs(b),
+    (b) => _dogDetector!.detect(b),
     _convertDogFaces,
-    () => _dogDetectorIsolate = null,
+    () => _dogDetector = null,
     'dog',
     filterByFaceSize: filterByFaceSize,
     imageWidth: imageWidth,

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -18,6 +18,9 @@ icon: "linux/packaging/deb/agelapse.png"
 
 dependencies:
   - ffmpeg
+  - libgtk-3-0 | libgtk-3-0t64
+  - libgstreamer1.0-0
+  - libgstreamer-plugins-base1.0-0
   - libmpv2 | libmpv1
   - libturbojpeg | libturbojpeg0
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: animal_detection
-      sha256: d70893f0863a6ba5054374e03be1a7b93aa807a9b58f945dd57992cf5d8ca68f
+      sha256: "7d34f6064c8997ff0e126d1abba49d32fa1f21ebd5357844cef3697cca86e074"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   animated_bottom_navigation_bar:
     dependency: "direct main"
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: "direct main"
     description:
       name: cat_detection
-      sha256: ebdf8982d6be694429b68c3b8149a990a79315eca743f2922e799a2ffab3a472
+      sha256: b7f4791ca8c66e993e691b327246f53c4979e0347cc8b584b76121af7745d1e0
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   change_case:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: "direct main"
     description:
       name: dog_detection
-      sha256: "670fe459bdbfa52182cc277cc06d6006bd55759bcbbb64f9cad8c7d1472f844d"
+      sha256: "1c204930e4a87492f28fde61062191e1c9004d42bfc1567dd0604df094b38a79"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   downloadsfolder:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: animal_detection
-      sha256: "9f8f5bad4217f87f2082111d650448cf0cee8f60b1071965a64dd6ac499f2355"
+      sha256: d70893f0863a6ba5054374e03be1a7b93aa807a9b58f945dd57992cf5d8ca68f
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   animated_bottom_navigation_bar:
     dependency: "direct main"
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: "direct main"
     description:
       name: cat_detection
-      sha256: "3c289a49d18c7d0966e2e26a3fbb6e9bc44363efbb1d3f28b53e6d712fd756ed"
+      sha256: ebdf8982d6be694429b68c3b8149a990a79315eca743f2922e799a2ffab3a472
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   change_case:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: "direct main"
     description:
       name: dog_detection
-      sha256: dc01d35b9d79cba3c9e1af63e814e0ac53d15f5a8a13b367d5d84b946f40b9bf
+      sha256: "670fe459bdbfa52182cc277cc06d6006bd55759bcbbb64f9cad8c7d1472f844d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   downloadsfolder:
     dependency: "direct main"
     description:
@@ -333,10 +333,10 @@ packages:
     dependency: "direct main"
     description:
       name: face_detection_tflite
-      sha256: "9535691721a9d6d1cf7f1aad310e2bacc6c657f6ae77096e9f1f59322cad0b23"
+      sha256: "72c31df2096a6102c17747c74a0cb511c89ad64f0fff0e93e1dd746f22531cf8"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.8.0"
   fake_async:
     dependency: transitive
     description:
@@ -580,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_litert
-      sha256: "5c9532db77272c878f0ca2a2d99547900fef7770de7cce45047984e73c0bfb1c"
+      sha256: "5428e65455b1f8ea01b4b874f39e0e434e9167e052a1218edb8a2e0ec2c7244a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.8.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -688,10 +688,10 @@ packages:
     dependency: "direct main"
     description:
       name: hand_detection
-      sha256: a5b170ceaf0e79a65066ac7bfe6d5c9be1091aacac5de6d032e04f1ab728aa75
+      sha256: c784fde6846d85626491e289052ecdc90a9f540e05fcba0a87d2dd2ca1e44867
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "4.1.0"
   heic_native:
     dependency: "direct main"
     description:
@@ -1141,10 +1141,10 @@ packages:
     dependency: "direct main"
     description:
       name: pose_detection
-      sha256: "3b9fb7b836975ad89f8dffa0824839b8f8149df675a5e3d78a27db3783454f4b"
+      sha256: a0cd9d48db876c0b16bbeaecec110a67e1baeabe572d10f3c730aa2299350883
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.7.0"
   posix:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: animal_detection
-      sha256: "5fa8348a5d67bc5244a36cef25488b053ed585f10270beadba613a35dd14810a"
+      sha256: "9f8f5bad4217f87f2082111d650448cf0cee8f60b1071965a64dd6ac499f2355"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "2.0.0"
   animated_bottom_navigation_bar:
     dependency: "direct main"
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: "direct main"
     description:
       name: cat_detection
-      sha256: d5fa77efc9f81b67255711f78883c857e6aad9c3645c4caddfdf86aba140c79f
+      sha256: "3c289a49d18c7d0966e2e26a3fbb6e9bc44363efbb1d3f28b53e6d712fd756ed"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "2.0.0"
   change_case:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: "direct main"
     description:
       name: dog_detection
-      sha256: ca565adaa4f883c82144e1d2cc739c690871bfce749ccf1a351e5ea98b29635f
+      sha256: dc01d35b9d79cba3c9e1af63e814e0ac53d15f5a8a13b367d5d84b946f40b9bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "2.0.0"
   downloadsfolder:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,9 +21,9 @@ dependencies:
   device_info_plus: ^13.2.0
   downloadsfolder: ^2.0.0-pre.2
   exif_reader: ^4.1.0
-  cat_detection: ^2.1.0
+  cat_detection: ^3.0.0
   crypto: ^3.0.0
-  dog_detection: ^2.1.0
+  dog_detection: ^3.0.0
   face_detection_tflite: ^6.8.0
   ffi: ^2.1.0
   hand_detection: ^4.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,12 +21,12 @@ dependencies:
   device_info_plus: ^13.2.0
   downloadsfolder: ^2.0.0-pre.2
   exif_reader: ^4.1.0
-  cat_detection: ^2.0.0
+  cat_detection: ^2.1.0
   crypto: ^3.0.0
-  dog_detection: ^2.0.0
-  face_detection_tflite: ^6.7.0
+  dog_detection: ^2.1.0
+  face_detection_tflite: ^6.8.0
   ffi: ^2.1.0
-  hand_detection: ^3.5.0
+  hand_detection: ^4.1.0
   ffmpeg_kit_flutter_new:
     path: plugins/ffmpeg_kit_flutter_new
   file_picker: ^12.0.0-beta.7
@@ -53,7 +53,7 @@ dependencies:
   path: ^1.9.1
   path_provider: ^2.1.6
   permission_handler: ^12.0.3
-  pose_detection: ^3.6.0
+  pose_detection: ^3.7.0
   provider: ^6.1.5
   saver_gallery: ^5.1.0
   sensors_plus: ^7.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,9 +21,9 @@ dependencies:
   device_info_plus: ^13.2.0
   downloadsfolder: ^2.0.0-pre.2
   exif_reader: ^4.1.0
-  cat_detection: ^1.4.0
+  cat_detection: ^2.0.0
   crypto: ^3.0.0
-  dog_detection: ^1.4.0
+  dog_detection: ^2.0.0
   face_detection_tflite: ^6.7.0
   ffi: ^2.1.0
   hand_detection: ^3.5.0


### PR DESCRIPTION
Moves off the deprecated `CatDetectorIsolate` / `DogDetectorIsolate` wrappers. Both packages collapsed their two entry classes into one in 2.0.0: `CatDetector` and `DogDetector` now own a background isolate internally, so the wrappers are thin delegates that will be removed next major. This matches the shape `_ensureFDLite` already used for `FaceDetector`: construct, then `await initialize()`.

### Binary size: ~84 MB smaller

Each package's bundled landmark model went from 57.29 MB to 11.55 MB. Float16 weights barely deflate (57.29 MB gzips to 52.71 MB), so nearly the whole saving reaches the shipped artifact.

### Pet stabilization: substantially faster

1.4.0's isolate defaulted to `PerformanceConfig.disabled`, so this app has been running detection with no XNNPACK at all. 2.0.0 defaults to auto. Combined with the smaller model and animal_detection 2.0.0's flat tensor path, detection measured on a 3264x2448 photo:

| | 1.4.0 | 2.0.0 |
|---|---|---|
| cat | 261.8 ms/frame | 113.7 ms |
| dog | 491.8 ms/frame | 114.5 ms |

Human faces go through `face_detection_tflite` and are unaffected.

### Eye-center math needs no change

cat_detection 2.0.0 swapped the `rightEyeTop` and `rightEyeBottom` labels, which were mislabelled: index 36 sits above 38 in only 2.9% of the CatFLW images, and the flip table pairs 36 with `leftEyeBottom`. `_computeEyeCenterFromCoords` averages all four eye landmarks, and that set is identical either way, so centers come out unchanged.

### Expect a one-time re-stabilization

animal_detection 2.0.0 fixes a sub-pixel crop bug, moving landmarks about 0.6px and improving accuracy. `modelVersionFor` now reports `2.0.0` / `pipeline_v3` where 1.4.0 reported `1.0.5` / `pipeline_v1`, so `transform_cache_key` invalidates and previously stabilized photos are reprocessed rather than mixed with new output.

### Verification

- `flutter analyze`: clean, no deprecation warnings
- `flutter test`: 1969 passed
- 3 files changed: `stabilizer_utils.dart`, `pubspec.yaml`, `pubspec.lock`

Note: this branch also carries `39ff1b2 fix(packaging): address package smoke failures`, which was its base and is not yet on main.