### PR TITLE
chore: release 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AgeLapse takes a raw photo, detects a set of landmarks on the person (eyes for f
 
 ## What's New / Changelog
 
-### v2.7.0 (June 2026)
+### v2.7.0 (August 2026)
 
 #### New Features
 - Recently Deleted

--- a/flatpak/com.hugocornellier.agelapse.metainfo.xml
+++ b/flatpak/com.hugocornellier.agelapse.metainfo.xml
@@ -56,10 +56,12 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="2.7.0-pre" date="2026-05-09">
+    <release version="2.7.0" date="2026-08-13">
       <description>
         <ul>
           <li>Recently deleted photos can be restored or permanently deleted.</li>
+          <li>Manual stabilization edits are saved and re-applied across re-stabilizations.</li>
+          <li>Faster stabilization and an inspection mode images-per-row control.</li>
         </ul>
       </description>
     </release>

--- a/lib/screens/info_page.dart
+++ b/lib/screens/info_page.dart
@@ -7,7 +7,7 @@ import '../services/log_service.dart';
 import '../styles/styles.dart';
 
 // Apple bundle versions are numeric, so the pre-release channel is tracked here.
-const bool kIsPreReleaseBuild = true;
+const bool kIsPreReleaseBuild = false;
 
 String formatInfoVersionLabel(
   PackageInfo info, {

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -1,6 +1,6 @@
 display_name: "AgeLapse"
 package_name: "agelapse"
-version: "2.7.0-pre"
+version: "2.7.0"
 architecture: "amd64"
 
 section: "utils"

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -1,6 +1,6 @@
 #define MyAppName "AgeLapse"
 #ifndef MyAppVersion
-  #define MyAppVersion "2.7.0-pre"
+  #define MyAppVersion "2.7.0"
 #endif
 #define MyAppPublisher "Hugo Cornellier"
 #define MyAppExeName "agelapse.exe"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: agelapse
 description: A powerful tool for creating stabilized aging timelapses.
 publish_to: 'none'
 
-version: 2.7.0-prerelease-B+46
+version: 2.7.0+47
 
 environment:
   sdk: ">=3.12.0 <4.0.0"


### PR DESCRIPTION
Promotes the prerelease build to the 2.7.0 release version ahead of the GitHub release.

- `pubspec.yaml`: `2.7.0-prerelease-B+46` -> `2.7.0+47`
- `lib/screens/info_page.dart`: clear `kIsPreReleaseBuild` so the info page shows `Version: 2.7.0` instead of `Version: 2.7.0 (Pre-Release)`
- `packaging/installer.iss`, `linux/packaging/deb/make_config.yaml`, `flatpak/com.hugocornellier.agelapse.metainfo.xml`: drop the `-pre` suffix (the Desktop Release workflow overrides the first two at build time, but the committed fallbacks should match the release)
- `README.md`: correct the v2.7.0 changelog date to August 2026

The Desktop Release workflow's `prepare` job hard-fails unless `pubspec.yaml` matches the release tag, so this has to land before `agelapse-v2.7.0` is dispatched.

Local gate: `tool/check_format.sh` clean, `flutter analyze --fatal-infos .` clean, `flutter test` 1969 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)