### PR TITLE
fix(linux): resolve bundled libraries from their own directory

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -186,6 +186,35 @@ jobs:
       - name: Build Linux release
         run: flutter build linux --release --build-name=${{ needs.prepare.outputs.version }} --build-number=${{ needs.prepare.outputs.build_number }}
 
+      # Plugin builds leave bundled libraries with either no RUNPATH at all or
+      # one baked to the CI checkout path. RUNPATH is not inherited by
+      # transitive dependencies, so libheif could not locate its sibling
+      # libde265 on a machine without those libraries installed system-wide,
+      # even though both ship inside the bundle. Point every bundled library at
+      # its own directory. This runs before deb, tarball, and Flatpak packaging
+      # so all three inherit the corrected libraries.
+      - name: Normalize bundled library RPATHs
+        run: |
+          sudo apt-get install -y patchelf
+
+          BUNDLE_LIB="build/linux/x64/release/bundle/lib"
+
+          while IFS= read -r -d '' LIBRARY; do
+            patchelf --set-rpath '$ORIGIN' "$LIBRARY" || {
+              echo "::error::patchelf failed on $LIBRARY"
+              exit 1
+            }
+          done < <(find "$BUNDLE_LIB" -type f -name '*.so*' -print0)
+
+          LEAKED=$(find "$BUNDLE_LIB" -type f -name '*.so*' \
+            -exec patchelf --print-rpath {} \; | grep -v '^\$ORIGIN$' || true)
+          if [ -n "$LEAKED" ]; then
+            echo "::error::Bundled libraries still reference paths outside the bundle:"
+            echo "$LEAKED"
+            exit 1
+          fi
+          echo "All bundled libraries resolve dependencies from their own directory."
+
       # --- .deb package ---
       - name: Install Fastforge
         run: dart pub global activate fastforge 0.6.6
@@ -437,7 +466,9 @@ jobs:
           while IFS= read -r -d '' LIBRARY; do
             if file "$LIBRARY" | grep -q 'ELF'; then
               echo "==> $LIBRARY" | tee -a "$RUNNER_TEMP/agelapse-deb-ldd.log"
-              LD_LIBRARY_PATH=/opt/agelapse/lib ldd "$LIBRARY" |
+              # Deliberately no LD_LIBRARY_PATH: the installed package has to
+              # resolve its own libraries the way it will on a user's machine.
+              ldd "$LIBRARY" |
                 tee -a "$RUNNER_TEMP/agelapse-deb-ldd.log"
             fi
           done < <(find /opt/agelapse -type f \
@@ -492,7 +523,9 @@ jobs:
           while IFS= read -r -d '' LIBRARY; do
             if file "$LIBRARY" | grep -q 'ELF'; then
               echo "==> $LIBRARY" | tee -a "$RUNNER_TEMP/agelapse-bundle-ldd.log"
-              LD_LIBRARY_PATH="$PWD/unpacked/bundle/lib" ldd "$LIBRARY" |
+              # Deliberately no LD_LIBRARY_PATH: the extracted bundle has to
+              # resolve its own libraries the way it will on a user's machine.
+              ldd "$LIBRARY" |
                 tee -a "$RUNNER_TEMP/agelapse-bundle-ldd.log"
             fi
           done < <(find unpacked/bundle -type f \

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ migrate_working_dir/
 .pub/
 /build/
 /coverage/
+/dist/
 
 app.*.symbols
 app.*.map.json


### PR DESCRIPTION
Blocks the 2.7.0 release. The Debian package smoke job added in d16b611 caught it on the first release run ([31740072465](https://github.com/hugocornellier/agelapse/actions/runs/31740072465)).

## The bug

```
/usr/bin/agelapse: error while loading shared libraries:
libde265.so.0: cannot open shared object file: No such file or directory
```

`libde265.so.0` ships in the bundle, directly beside `libheif.so.1`. But `libheif.so.1` has no RUNPATH, and RUNPATH is not inherited by transitive dependencies. So the loader finds `libheif` through the executable's `$ORIGIN/lib`, then goes looking for `libde265` using *libheif's* search path, which is empty, and never checks the directory the file is actually in. On any machine without `libde265` installed system-wide, the app does not start.

Confirmed by parsing the ELF dynamic sections of the built `.deb`:

| Library | RUNPATH |
| --- | --- |
| `agelapse` | `$ORIGIN/lib:$ORIGIN/../lib:/usr/lib:...` |
| `libheif.so.1` | none, needs `libde265.so.0` |
| `libde265.so.0` | none |
| `libheic_native_plugin.so` | `/home/runner/work/agelapse/agelapse/linux/flutter/ephemeral/...` |

Ten bundled libraries have no RUNPATH at all. A further 17 carry a RUNPATH pointing at the CI checkout under `/home/runner`, a path that exists on no user's machine.

## Why the other smoke jobs passed

The bundle tarball job installs `libheif-dev` before launching, which pulls system `libde265` and masks it. The Flatpak gets its libraries from the runtime. So the tarball carries the same latent defect and only appears healthy.

## Not a 2.7.0 regression

The shipped 2.6.0 `.deb` has the identical defect: `libheif.so.1` with no RUNPATH, `libde265.so.0` bundled beside it, 18 libraries with leaked `/home/runner` paths, and no `libheif`/`libde265` in `Depends`. Only the install prefix differs (`/usr/share/agelapse` then, `/opt/agelapse` now).

## The fix

Normalize every bundled library to `$ORIGIN` after the Linux build and before deb, tarball, and Flatpak packaging, so all three inherit it. The step fails the job if any library still points outside the bundle.

Both smoke jobs also ran `ldd` with `LD_LIBRARY_PATH` set to the bundle directory, which resolves everything globally and reported a clean result for a package that could not launch. Dropped, so the check exercises the same resolution path a user's machine will.

## Verification

The `.deb` smoke job is the real test here: it installs onto a clean runner with only the package's declared `Depends`, then launches. It is what caught this, and it is what will confirm the fix.

Not verified locally (no Linux/patchelf available on the release machine).

## Scope

Packaging only, Linux only. No app code changes, so `pubspec.yaml` stays at `2.7.0+47` and the already-built, signed and notarized macOS zip and the signed APK remain valid for the release.

## Follow-ups not in this PR

- The bundle smoke job installs `-dev` packages before a *runtime* test, which is what masked this for the tarball. Worth reducing to runtime packages so it tests a clean machine too.
- The deb's `Depends` lists neither `libheif` nor `libde265`; correct now that they are bundled and resolvable, but worth an audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)