### PR TITLE
fix(linux): normalize bundled RPATHs after fastforge rebuilds the bundle

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -186,34 +186,8 @@ jobs:
       - name: Build Linux release
         run: flutter build linux --release --build-name=${{ needs.prepare.outputs.version }} --build-number=${{ needs.prepare.outputs.build_number }}
 
-      # Plugin builds leave bundled libraries with either no RUNPATH at all or
-      # one baked to the CI checkout path. RUNPATH is not inherited by
-      # transitive dependencies, so libheif could not locate its sibling
-      # libde265 on a machine without those libraries installed system-wide,
-      # even though both ship inside the bundle. Point every bundled library at
-      # its own directory. This runs before deb, tarball, and Flatpak packaging
-      # so all three inherit the corrected libraries.
-      - name: Normalize bundled library RPATHs
-        run: |
-          sudo apt-get install -y patchelf
-
-          BUNDLE_LIB="build/linux/x64/release/bundle/lib"
-
-          while IFS= read -r -d '' LIBRARY; do
-            patchelf --set-rpath '$ORIGIN' "$LIBRARY" || {
-              echo "::error::patchelf failed on $LIBRARY"
-              exit 1
-            }
-          done < <(find "$BUNDLE_LIB" -type f -name '*.so*' -print0)
-
-          LEAKED=$(find "$BUNDLE_LIB" -type f -name '*.so*' \
-            -exec patchelf --print-rpath {} \; | grep -v '^\$ORIGIN$' || true)
-          if [ -n "$LEAKED" ]; then
-            echo "::error::Bundled libraries still reference paths outside the bundle:"
-            echo "$LEAKED"
-            exit 1
-          fi
-          echo "All bundled libraries resolve dependencies from their own directory."
+      - name: Install patchelf
+        run: sudo apt-get install -y patchelf
 
       # --- .deb package ---
       - name: Install Fastforge
@@ -227,6 +201,71 @@ jobs:
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"
           fastforge package --platform linux --targets deb
+
+      # Bundled libraries carry either no RUNPATH at all or one baked to the CI
+      # checkout path, and RUNPATH is not inherited by transitive dependencies,
+      # so libheif cannot locate its sibling libde265 on a machine without those
+      # libraries installed system-wide even though both ship in the bundle.
+      #
+      # This must run *after* the .deb build: fastforge re-runs
+      # `flutter build linux` itself, which regenerates the bundle and discards
+      # any earlier patching. It normalizes the staged bundle, which the tarball
+      # and Flatpak below are both created from, and rewrites the .deb payload
+      # in place.
+      - name: Normalize bundled library RPATHs
+        run: |
+          normalize() {
+            LIB_DIR="$1"
+
+            while IFS= read -r -d '' LIBRARY; do
+              patchelf --set-rpath '$ORIGIN' "$LIBRARY" || {
+                echo "::error::patchelf failed on $LIBRARY"
+                exit 1
+              }
+            done < <(find "$LIB_DIR" -type f -name '*.so*' -print0)
+
+            LEAKED=$(find "$LIB_DIR" -type f -name '*.so*' \
+              -exec patchelf --print-rpath {} \; | grep -v '^\$ORIGIN$' || true)
+            if [ -n "$LEAKED" ]; then
+              echo "::error::Libraries in $LIB_DIR still reference paths outside the bundle:"
+              echo "$LEAKED"
+              exit 1
+            fi
+            echo "Normalized $LIB_DIR"
+          }
+
+          normalize build/linux/x64/release/bundle/lib
+
+          # Prove $ORIGIN actually expands, rather than trusting that setting it
+          # was enough. libde265 is installed system-wide on this runner, so if
+          # RUNPATH were not working this would silently resolve to /lib and the
+          # defect would reach the smoke jobs again.
+          RESOLVED=$(ldd build/linux/x64/release/bundle/lib/libheif.so.1 |
+            awk '/libde265/ {print $3}')
+          case "$RESOLVED" in
+            */bundle/lib/*)
+              echo "libheif resolves libde265 from the bundle: $RESOLVED"
+              ;;
+            *)
+              echo "::error::libheif resolved libde265 from '$RESOLVED' rather than the bundle."
+              exit 1
+              ;;
+          esac
+
+          DEB_FILE=$(find dist -name '*.deb' -type f | head -1)
+          sudo rm -rf deb-root
+          dpkg-deb -R "$DEB_FILE" deb-root
+          DEB_LIB=$(dirname "$(find deb-root -name 'libflutter_linux_gtk.so' -print -quit)")
+          normalize "$DEB_LIB"
+          # dpkg-deb records the ownership it finds on disk, and the unpacked
+          # tree belongs to the runner user. Restore root:root so the rebuilt
+          # package installs with the same ownership fastforge produced.
+          sudo chown -R root:root deb-root
+          sudo dpkg-deb -b deb-root "$DEB_FILE"
+          sudo chown "$(id -u):$(id -g)" "$DEB_FILE"
+          sudo rm -rf deb-root
+
+          dpkg-deb -c "$DEB_FILE" | head -5
 
       - name: Rename .deb
         run: |


### PR DESCRIPTION
Follow-up to #52, which fixed the right thing in the wrong place. Still blocking the 2.7.0 release.

## What went wrong with #52

#52 patched the bundle immediately after `flutter build linux`. But `fastforge package` runs `flutter build linux` *again*, from the deb step's own log:

```
Build .deb package  11:16:42  $ flutter build linux --build-name 2.7.0 --build-number 47
Build .deb package  11:22:02  ✓ Built build/linux/x64/release/bundle/agelapse
```

That regenerated the bundle and discarded every patched library. The tarball and Flatpak are created from the same regenerated tree, so all three packages shipped unpatched, and [run 31794141172](https://github.com/hugocornellier/agelapse/actions/runs/31794141172) failed both Linux smoke jobs on unresolved `libde265.so.0` and `libflutter_linux_gtk.so`.

The step itself was fine: it ran, verified, and reported success. It just ran before the last thing that regenerates the bundle.

## The fix

Move normalization to after the `.deb` build, the last step that regenerates the bundle. It now:

- normalizes the staged bundle, which the tarball and Flatpak are both created from further down
- rewrites the `.deb` payload in place with `dpkg-deb -R` / `-b`, restoring `root:root` first, since the unpacked tree belongs to the runner user and `dpkg-deb` records whatever ownership it finds (verified the original payload is `root:root`)

## Assertion instead of hope

The build runner has `libde265` installed system-wide via `libheif-dev`, which means a non-working RUNPATH resolves silently to `/lib` and the defect only surfaces two jobs later. So the step now proves `$ORIGIN` expands:

```bash
RESOLVED=$(ldd .../bundle/lib/libheif.so.1 | awk '/libde265/ {print $3}')
case "$RESOLVED" in
  */bundle/lib/*) ;;   # resolved from the bundle, RUNPATH works
  *) exit 1 ;;         # resolved from the system, RUNPATH does not
esac
```

That converts a two-jobs-later smoke failure into an immediate, legible one in the build job.

## Verification

Still not reproducible locally (no Linux or patchelf on the release machine). The `.deb` smoke job remains the authority: clean runner, only the package's declared `Depends`, then launch. The new assertion should catch a broken RUNPATH well before it gets there.

## Scope

Packaging only, Linux only. `pubspec.yaml` stays at `2.7.0+47`; the signed and notarized macOS zip and the signed APK remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)