### PR TITLE
fix(ci): tolerate the expected absent libjvm.so in Linux smoke checks

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -512,8 +512,16 @@ jobs:
             fi
           done < <(find /opt/agelapse -type f \
             \( -name agelapse -o -name '*.so' -o -name '*.so.*' \) -print0)
-          if grep -q 'not found' "$RUNNER_TEMP/agelapse-deb-ldd.log"; then
+          # libjvm.so is expected to be absent. It is needed only by
+          # libdartjni.so, which package:jni dlopens on demand for Android;
+          # nothing in the bundle links it, so it is never loaded on Linux.
+          # Its RUNPATH used to point at the CI runner's JDK, which resolved
+          # here and nowhere else.
+          UNRESOLVED=$(grep 'not found' "$RUNNER_TEMP/agelapse-deb-ldd.log" |
+            grep -v 'libjvm\.so' || true)
+          if [ -n "$UNRESOLVED" ]; then
             echo "::error::The installed Debian package has unresolved shared libraries."
+            echo "$UNRESOLVED"
             exit 1
           fi
 
@@ -569,8 +577,12 @@ jobs:
             fi
           done < <(find unpacked/bundle -type f \
             \( -name agelapse -o -name '*.so' -o -name '*.so.*' \) -print0)
-          if grep -q 'not found' "$RUNNER_TEMP/agelapse-bundle-ldd.log"; then
+          # See the Debian job for why an absent libjvm.so is expected.
+          UNRESOLVED=$(grep 'not found' "$RUNNER_TEMP/agelapse-bundle-ldd.log" |
+            grep -v 'libjvm\.so' || true)
+          if [ -n "$UNRESOLVED" ]; then
             echo "::error::The extracted Linux bundle has unresolved shared libraries."
+            echo "$UNRESOLVED"
             exit 1
           fi
 


### PR DESCRIPTION
Third and final piece of the 2.7.0 Linux packaging fix. Follows #52 and #53.

## The RPATH fix works

[Run 31823173701](https://github.com/hugocornellier/agelapse/actions/runs/31823173701) confirms it:

- `Build Linux Packages` passed, meaning the new `$ORIGIN` assertion held: `libheif` resolves `libde265` to the bundle copy, not the system one
- `libde265.so.0 => not found` and `libflutter_linux_gtk.so => not found` are gone from both smoke jobs

## What is left

One unresolved library, and it is expected to be absent:

```
libjvm.so => not found
```

`libjvm.so` is needed only by `libdartjni.so`, which `package:jni` `dlopen`s on demand for Android. Verified that **nothing in the bundle links `libdartjni.so`**, so it is never loaded on Linux desktop and its dependency is never required.

Before normalization it carried:

```
libdartjni.so  RUNPATH: /usr/lib/jvm/temurin-17-jdk-amd64/lib/server
```

the CI runner's JDK. That resolved on the runner and on no user's machine. Stripping it was correct; it just made an always-absent dependency visible for the first time.

For completeness, every distinct RUNPATH in the pre-fix package:

| Count | RUNPATH |
| --- | --- |
| 16 | `/home/runner/work/agelapse/agelapse/linux/flutter/ephemeral` |
| 10 | none |
| 3 | `$ORIGIN` |
| 1 | `/home/runner/.../.plugin_symlinks/heic_native/linux/third_party/lib:...` |
| 1 | `/usr/lib/jvm/temurin-17-jdk-amd64/lib/server` (`libdartjni.so`) |
| 1 | `$ORIGIN/lib:$ORIGIN/../lib:/usr/lib:...` (the executable, untouched) |

So `libjvm.so` is the only legitimate leftover.

## The change

Narrow both smoke gates to ignore `libjvm.so` specifically, rather than reverting the hardening. Everything else still fails the job. They now also print the offending lines instead of only announcing that something is unresolved.

Grep logic verified locally against both a libjvm-only log (passes) and a log with a real miss (fails, and reports `libde265.so.0`).

## Scope

Packaging and CI only, Linux only. `pubspec.yaml` stays at `2.7.0+47`; the signed and notarized macOS zip and the signed APK remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)