### PR TITLE
fix(linux): declare the GL runtime the Flutter embedder dlopens

### DIFF
--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -23,6 +23,13 @@ dependencies:
   - libgstreamer-plugins-base1.0-0
   - libmpv2 | libmpv1
   - libturbojpeg | libturbojpeg0
+  # The Flutter Linux embedder dlopens libGLESv2.so.2 and libEGL.so.1 at
+  # startup and aborts if either is missing. Because they are dlopened rather
+  # than linked, they never appear in ldd output, so only launching the app
+  # catches their absence. They arrive transitively on developer machines via
+  # the -dev packages, which is why this went unnoticed.
+  - libgles2 | libgles2-mesa
+  - libegl1 | libegl1-mesa
 
 generic_name: "Timelapse Creator"
 categories:


### PR DESCRIPTION
Last piece of the 2.7.0 Linux packaging fix. Follows #52, #53, #54.

## Where we got to

[Run 31832625341](https://github.com/hugocornellier/agelapse/actions/runs/31832625341): Windows, Flatpak, and **Linux bundle** all pass. The bundle job got past the hardened `ldd` gate and launched successfully, so the RPATH work from #53 is confirmed good.

The `.deb` job installed cleanly, resolved every library, and then aborted:

```
Couldn't open libGLESv2.so.2: cannot open shared object file: No such file or directory
Aborted (core dumped)
```

Exit code 134, SIGABRT.

## Why no check could have caught this

The Flutter Linux embedder **`dlopen`s** `libGLESv2.so.2` and `libEGL.so.1` rather than linking them. They never appear as `NEEDED` entries, so they are invisible to `ldd` no matter how the check is written. Only actually launching the app finds them. Nothing in the package's `Depends` pulled in the GL runtime.

## Why only the Debian job caught it

| Job | GL comes from | Result |
| --- | --- | --- |
| Bundle | installs `libgtk-3-dev` etc., which drag in the GL stack | passed |
| Flatpak | the Flatpak runtime | passed |
| **Debian** | **only the package's declared `Depends`** | **caught it** |

The Debian job is the only one testing the honest clean-machine condition. Worth keeping in mind: the bundle job's use of `-dev` packages is the same thing that masked the `libde265` bug for three cycles.

## The fix

Declare the GL runtime in the deb's dependencies, with alternatives for older releases.

Verified against the Ubuntu archive rather than assumed:
- `libgles2` ships `/usr/lib/x86_64-linux-gnu/libGLESv2.so.2` (confirmed via the noble filelist)
- all four package names resolve in noble, so both `|` alternatives are valid

## Pre-existing

2.6.0 declares `ffmpeg, libmpv2 | libmpv1, libturbojpeg | libturbojpeg0` and no GL packages at all, so its `.deb` has the same defect.

## Scope

Packaging only, Linux only. `pubspec.yaml` stays at `2.7.0+47`; the signed and notarized macOS zip and signed APK remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)