### PR TITLE
ci: drop the tag-push trigger from Desktop Release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,9 +1,14 @@
 name: Desktop Release
 
+# Dispatch only. A tag-push trigger cannot work with how releases are actually
+# cut: the flow builds a draft, attaches the hand-built macOS and Android
+# assets, and then publishes, and publishing is what creates the tag. So the tag
+# always arrives after the release exists, and the prepare job's own
+# "release already exists" guard fails the run, leaving a red X on the released
+# commit. Releasing by tag push was never viable anyway, since that path has no
+# draft input and would publish immediately without the two assets CI cannot
+# build.
 on:
-  push:
-    tags:
-      - 'agelapse-v*.*.*'
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
Publishing 2.7.0 left a red X on the released commit, visible to anyone landing on the repo.

## Cause

1. Publishing the draft **creates** the tag `agelapse-v2.7.0`
2. Desktop Release triggers on `push: tags: ['agelapse-v*.*.*']`, so a second run fires
3. That run fails on the prepare job's own guard:

```
##[error]Release 'agelapse-v2.7.0' already exists. Delete it first or use a new version.
```

This is structural, not a one-off. The release flow necessarily builds a draft, attaches the macOS zip and APK that CI cannot build, and publishes afterwards. Publishing is what creates the tag, so the tag always arrives after the release exists, and that trigger can only ever fail. Every future release would repeat it.

## Why the tag path was never usable anyway

- no `draft` input on that path, so it publishes immediately and publicly
- `publish-release` forces `--prerelease` on anything non-draft
- it would go out with the two hand-built assets missing

So the trigger offered nothing the dispatch path doesn't, and actively produced a failing run.

## Change

Dispatch-only, with a comment recording why so nobody restores the trigger.

The spurious run (32021438153) has already been deleted, so the X is cleared on `main` today. This prevents a recurrence on 2.8.0.

## Deliberately not done

Two `github.event_name` branches in `prepare` and `publish-release` are now unreachable. Left in place: they are harmless, and editing more of this workflow immediately after a release depends on it is not worth the risk. Worth folding into the pending cleanup PR alongside the bundle smoke job's `-dev` packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)