### PR TITLE
ci: test the tarball on a clean machine, and stop cleanup from failing tests

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -549,11 +549,21 @@ jobs:
       - name: Extract, inspect, and launch Linux bundle
         if: matrix.kind == 'bundle'
         run: |
+          # Runtime packages only, mirroring what the .deb declares, so the
+          # tarball is exercised the way a user's machine will run it. Installing
+          # -dev packages here dragged in libheif, libde265 and the GL stack
+          # transitively, which is why this job reported success for a bundle
+          # whose libraries could not resolve each other, and again for one that
+          # aborted on a missing libGLESv2. Keep in sync with
+          # linux/packaging/deb/make_config.yaml.
           sudo apt-get install -y \
             ffmpeg \
-            libgtk-3-dev \
-            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-            libmpv-dev libheif-dev libpng-dev libturbojpeg0-dev
+            libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
+            libmpv2 libgles2 libegl1
+          # GTK and turbojpeg were renamed by the 64-bit time_t transition, and
+          # the .deb declares both spellings as alternatives. Accept either.
+          sudo apt-get install -y libgtk-3-0t64 || sudo apt-get install -y libgtk-3-0
+          sudo apt-get install -y libturbojpeg || sudo apt-get install -y libturbojpeg0
 
           BUNDLE_FILE=$(find package -maxdepth 1 -type f -name '*.tar.gz' -print -quit)
           if [ -z "$BUNDLE_FILE" ]; then

--- a/flatpak/com.hugocornellier.agelapse.flathub.yaml
+++ b/flatpak/com.hugocornellier.agelapse.flathub.yaml
@@ -142,11 +142,11 @@ modules:
       - install -Dm644 LICENSE /app/share/licenses/com.hugocornellier.agelapse/LICENSE
 
     sources:
-      # Pre-built Flutter bundle from GitHub release
-      # TODO: Update URL and sha256 after uploading to GitHub releases
+      # Pre-built Flutter bundle from GitHub release. The filename pattern is
+      # set by the Desktop Release workflow: agelapse-linux-<version>-x64-bundle.tar.gz
       - type: archive
-        url: https://github.com/hugocornellier/agelapse/releases/download/agelapse-v2.7.0-pre/agelapse-linux-v2.7.0-pre-bundle.tar.gz
-        sha256: 3ab4ca5c9ac2ba257a08b8f225052711b94d2a9c83bfdcc706bca37cc468a85f
+        url: https://github.com/hugocornellier/agelapse/releases/download/agelapse-v2.7.0/agelapse-linux-2.7.0-x64-bundle.tar.gz
+        sha256: 05adc26eda113db7e43890ae6643b47ce5e53a9a02e1022037ea39f5c3bc0649
         dest: bundle
 
       # Wrapper script
@@ -157,7 +157,7 @@ modules:
       # Desktop entry
       - type: file
         url: https://raw.githubusercontent.com/hugocornellier/agelapse/main/flatpak/com.hugocornellier.agelapse.desktop
-        sha256: ed7f6c93de9e8179f16f0f1b49611bb434c45907fb3fc4431d9ff5f5345a9e3e
+        sha256: 8879ce31a646e1c52c52ab68d3fec43c0882a58c359963241ff1aed5870dc738
 
       # Icons - fetched individually
       - type: file
@@ -181,7 +181,7 @@ modules:
       # App metadata
       - type: file
         url: https://raw.githubusercontent.com/hugocornellier/agelapse/main/flatpak/com.hugocornellier.agelapse.metainfo.xml
-        sha256: 0c49282366971344dd9ffdc2777d2505e3d30abdbe052c249c7c90cf8d8d1dc4
+        sha256: 3585b536723bd016a85a8236658b5a1ff3405b657e0d1d07defae6dda25163f8
 
       # License file
       - type: file

--- a/integration_test/e2e_pipeline_test.dart
+++ b/integration_test/e2e_pipeline_test.dart
@@ -58,7 +58,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}

--- a/integration_test/export_test.dart
+++ b/integration_test/export_test.dart
@@ -81,7 +81,7 @@ void main() {
           final exportsDir = await DirUtils.getExportsDirPath(testProjectId!);
           final dir = Directory(exportsDir);
           if (await dir.exists()) {
-            await dir.delete(recursive: true);
+            await deleteQuietly(dir);
           }
         } catch (_) {}
 
@@ -90,7 +90,7 @@ void main() {
           final rawDir = await DirUtils.getRawPhotoDirPath(testProjectId!);
           final dir = Directory(rawDir);
           if (await dir.exists()) {
-            await dir.delete(recursive: true);
+            await deleteQuietly(dir);
           }
         } catch (_) {}
 

--- a/integration_test/face_detection_cache_benchmark_test.dart
+++ b/integration_test/face_detection_cache_benchmark_test.dart
@@ -735,7 +735,7 @@ Future<void> _cleanupProject(int projectId) async {
   try {
     final projectDir = await DirUtils.getProjectDirPath(projectId);
     if (await Directory(projectDir).exists()) {
-      await Directory(projectDir).delete(recursive: true);
+      await deleteQuietly(Directory(projectDir));
     }
     await DB.instance.deleteProjectCascade(projectId);
   } catch (_) {}

--- a/integration_test/ffmpeg_binary_test.dart
+++ b/integration_test/ffmpeg_binary_test.dart
@@ -8,6 +8,8 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:image/image.dart' as img;
 
+import 'test_utils.dart';
+
 /// Integration tests that verify bundled ffmpeg binaries can execute on a
 /// stock Windows machine (no dev tools in PATH).
 ///
@@ -27,7 +29,7 @@ void main() {
       final tempDir = await getTemporaryDirectory();
       final testBinDir = Directory(p.join(tempDir.path, 'ffmpeg_test'));
       if (await testBinDir.exists()) {
-        await testBinDir.delete(recursive: true);
+        await deleteQuietly(testBinDir);
       }
       await testBinDir.create(recursive: true);
 
@@ -94,7 +96,7 @@ void main() {
       );
 
       // Cleanup.
-      await testBinDir.delete(recursive: true);
+      await deleteQuietly(testBinDir);
     });
 
     testWidgets('drawtext filter works with bundled binary', (tester) async {
@@ -109,7 +111,7 @@ void main() {
       final tempDir = await getTemporaryDirectory();
       final testDir = Directory(p.join(tempDir.path, 'drawtext_test'));
       if (await testDir.exists()) {
-        await testDir.delete(recursive: true);
+        await deleteQuietly(testDir);
       }
       await testDir.create(recursive: true);
 
@@ -210,7 +212,7 @@ void main() {
       );
 
       // Cleanup
-      await testDir.delete(recursive: true);
+      await deleteQuietly(testDir);
     });
   });
 }

--- a/integration_test/gallery_test.dart
+++ b/integration_test/gallery_test.dart
@@ -46,7 +46,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}
@@ -617,7 +617,7 @@ void main() {
           try {
             final dirB = await DirUtils.getProjectDirPath(projectBId);
             if (await Directory(dirB).exists()) {
-              await Directory(dirB).delete(recursive: true);
+              await deleteQuietly(Directory(dirB));
             }
             await DB.instance.deleteProject(projectBId);
           } catch (_) {}

--- a/integration_test/image_format_test.dart
+++ b/integration_test/image_format_test.dart
@@ -376,7 +376,7 @@ void main() {
                     );
                   }
                 } finally {
-                  await tempDir.delete(recursive: true);
+                  await deleteQuietly(tempDir);
                 }
               } else {
                 // iOS: sips not available, skip import pipeline test
@@ -426,7 +426,7 @@ void main() {
                     );
                   }
                 } finally {
-                  await tempDir.delete(recursive: true);
+                  await deleteQuietly(tempDir);
                 }
               } else {
                 // iOS: sips not available, skip import pipeline test
@@ -477,7 +477,7 @@ void main() {
                   reason: 'AVIF/$day should produce a thumbnail',
                 );
               } finally {
-                await tempDir.delete(recursive: true);
+                await deleteQuietly(tempDir);
               }
             }
           },
@@ -655,7 +655,7 @@ void main() {
 
     tearDown(() async {
       if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
+        await deleteQuietly(tempDir);
       }
     });
 
@@ -749,7 +749,7 @@ void main() {
 
     tearDown(() async {
       if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
+        await deleteQuietly(tempDir);
       }
     });
 

--- a/integration_test/import_read_amplification_benchmark_test.dart
+++ b/integration_test/import_read_amplification_benchmark_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path_provider/path_provider.dart';
 
+import 'test_utils.dart';
+
 /// On-device version of test/utils/import_read_amplification_benchmark_test.dart
 /// for Finding #7 (the import pipeline reads each source file ~4x).
 ///
@@ -107,7 +109,7 @@ void main() {
 
   tearDown(() async {
     try {
-      await dir.delete(recursive: true);
+      await deleteQuietly(dir);
     } catch (_) {}
   });
 

--- a/integration_test/import_test.dart
+++ b/integration_test/import_test.dart
@@ -44,7 +44,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}
@@ -93,7 +93,7 @@ void main() {
           );
         } finally {
           notifier.dispose();
-          await tempDir.delete(recursive: true);
+          await deleteQuietly(tempDir);
         }
 
         expect(
@@ -211,7 +211,7 @@ void main() {
         expect(storedDate.month, 3, reason: 'Month should be 3 (March)');
         expect(storedDate.day, 15, reason: 'Day should be 15');
       } finally {
-        await tempDir.delete(recursive: true);
+        await deleteQuietly(tempDir);
       }
     });
 
@@ -300,7 +300,7 @@ void main() {
             reason: 'Timestamp should be midnight of the file modified date',
           );
         } finally {
-          await tempDir.delete(recursive: true);
+          await deleteQuietly(tempDir);
         }
       },
     );
@@ -476,7 +476,7 @@ void main() {
           );
         } finally {
           notifier.dispose();
-          await tempDir.delete(recursive: true);
+          await deleteQuietly(tempDir);
         }
       },
     );
@@ -522,7 +522,7 @@ void main() {
           }
         } finally {
           notifier.dispose();
-          await tempDir.delete(recursive: true);
+          await deleteQuietly(tempDir);
         }
 
         // Allow all isolate-based processing to complete
@@ -645,7 +645,7 @@ void main() {
             reason: 'All 3 valid JPEGs should be imported; tiny entry filtered',
           );
         } finally {
-          await tempDir.delete(recursive: true);
+          await deleteQuietly(tempDir);
         }
       },
     );
@@ -748,7 +748,7 @@ void main() {
           try {
             final targetDir = await DirUtils.getProjectDirPath(targetProjectId);
             if (await Directory(targetDir).exists()) {
-              await Directory(targetDir).delete(recursive: true);
+              await deleteQuietly(Directory(targetDir));
             }
             await DB.instance.deleteProject(targetProjectId);
           } catch (_) {}
@@ -810,7 +810,7 @@ void main() {
           reason: 'No importable entries -> no photos, no error',
         );
       } finally {
-        await tempDir.delete(recursive: true);
+        await deleteQuietly(tempDir);
       }
     });
 
@@ -864,7 +864,7 @@ void main() {
           reason: 'Image under a UTF-8 entry name should import',
         );
       } finally {
-        await tempDir.delete(recursive: true);
+        await deleteQuietly(tempDir);
       }
     });
 
@@ -925,7 +925,7 @@ void main() {
         final photos = await DB.instance.getPhotosByProjectID(testProjectId!);
         expect(photos, isEmpty, reason: 'A corrupt ZIP should import nothing');
       } finally {
-        await tempDir.delete(recursive: true);
+        await deleteQuietly(tempDir);
       }
     });
   });

--- a/integration_test/linked_source_sync_test.dart
+++ b/integration_test/linked_source_sync_test.dart
@@ -88,7 +88,7 @@ void main() {
       try {
         final rawDir = await DirUtils.getRawPhotoDirPath(testProjectId!);
         final dir = Directory(rawDir);
-        if (await dir.exists()) await dir.delete(recursive: true);
+        await deleteQuietly(dir);
       } catch (_) {}
       try {
         await DB.instance.deleteProject(testProjectId!);
@@ -99,7 +99,7 @@ void main() {
     if (tempLinkedDir != null) {
       try {
         if (await tempLinkedDir!.exists()) {
-          await tempLinkedDir!.delete(recursive: true);
+          await deleteQuietly(tempLinkedDir!);
         }
       } catch (_) {}
       tempLinkedDir = null;

--- a/integration_test/multipass_benchmark_test.dart
+++ b/integration_test/multipass_benchmark_test.dart
@@ -13,6 +13,8 @@ import 'package:agelapse/utils/dir_utils.dart';
 import 'package:agelapse/utils/test_mode.dart' as test_config;
 import 'package:path/path.dart' as p;
 
+import 'test_utils.dart';
+
 /// Multi-pass benchmark using Taylor Swift photo set.
 ///
 /// Uses a larger, more varied photo set to exercise multi-pass stabilization
@@ -89,7 +91,7 @@ void main() {
       try {
         final projectDir = await DirUtils.getProjectDirPath(projectId);
         if (await Directory(projectDir).exists()) {
-          await Directory(projectDir).delete(recursive: true);
+          await deleteQuietly(Directory(projectDir));
         }
         await DB.instance.deleteProject(projectId);
       } catch (_) {}

--- a/integration_test/recently_deleted_page_test.dart
+++ b/integration_test/recently_deleted_page_test.dart
@@ -13,6 +13,8 @@ import 'package:agelapse/utils/test_mode.dart' as test_config;
 import 'package:image/image.dart' as img;
 import 'package:path/path.dart' as p;
 
+import 'test_utils.dart';
+
 /// Widget-level tests for [RecentlyDeletedPage].
 ///
 /// Companion to the headless tests in `gallery_test.dart` (Tests D-J).
@@ -43,7 +45,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}

--- a/integration_test/settings_pipeline_test.dart
+++ b/integration_test/settings_pipeline_test.dart
@@ -45,7 +45,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}
@@ -361,7 +361,7 @@ void main() {
           try {
             final dirB = await DirUtils.getProjectDirPath(projectBId);
             if (await Directory(dirB).exists()) {
-              await Directory(dirB).delete(recursive: true);
+              await deleteQuietly(Directory(dirB));
             }
             await DB.instance.deleteProject(projectBId);
           } catch (_) {}

--- a/integration_test/stab_cache_test.dart
+++ b/integration_test/stab_cache_test.dart
@@ -580,7 +580,7 @@ void main() {
         try {
           final dir = await DirUtils.getProjectDirPath(projectId!);
           if (await Directory(dir).exists()) {
-            await Directory(dir).delete(recursive: true);
+            await deleteQuietly(Directory(dir));
           }
           await DB.instance.deleteProject(projectId!);
         } catch (_) {}

--- a/integration_test/stabilization_benchmark_test.dart
+++ b/integration_test/stabilization_benchmark_test.dart
@@ -176,7 +176,7 @@ void main() {
       try {
         final projectDir = await DirUtils.getProjectDirPath(projectId);
         if (await Directory(projectDir).exists()) {
-          await Directory(projectDir).delete(recursive: true);
+          await deleteQuietly(Directory(projectDir));
         }
         await DB.instance.deleteProject(projectId);
       } catch (_) {}

--- a/integration_test/test_utils.dart
+++ b/integration_test/test_utils.dart
@@ -307,6 +307,29 @@ Future<void> preloadFixtures() async {
   }
 }
 
+/// Deletes [dir] recursively without ever failing the calling test.
+///
+/// Cleanup is best effort and must never decide a test's outcome. On Windows a
+/// process the test spawned, typically ffmpeg, can still hold a handle when the
+/// test body finishes, and deleting a directory with an open handle fails with
+/// errno 32 where POSIX would happily unlink it. That produced CI failures whose
+/// assertions had all passed, and inside a `finally` block it also masked the
+/// real result. Retry briefly to let handles close, then give up quietly; the
+/// operating system reclaims temporary directories regardless.
+Future<void> deleteQuietly(Directory dir) async {
+  for (var attempt = 0; attempt < 5; attempt++) {
+    try {
+      if (!await dir.exists()) return;
+      await dir.delete(recursive: true);
+      return;
+    } on FileSystemException {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+  }
+  // ignore: avoid_print
+  print('cleanup: could not delete ${dir.path}; ignoring');
+}
+
 /// Cleans up extracted fixture files.
 /// Call this in tearDownAll() if needed.
 Future<void> cleanupFixtures() async {
@@ -315,9 +338,7 @@ Future<void> cleanupFixtures() async {
   final tempDir = await getTemporaryDirectory();
   final fixturesDir = Directory(p.join(tempDir.path, 'test_fixtures'));
 
-  if (await fixturesDir.exists()) {
-    await fixturesDir.delete(recursive: true);
-  }
+  await deleteQuietly(fixturesDir);
 
   _fixtureCache.clear();
 }

--- a/integration_test/transparent_alpha_pipeline_test.dart
+++ b/integration_test/transparent_alpha_pipeline_test.dart
@@ -53,7 +53,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}

--- a/integration_test/video_codec_test.dart
+++ b/integration_test/video_codec_test.dart
@@ -42,7 +42,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}

--- a/integration_test/video_compilation_test.dart
+++ b/integration_test/video_compilation_test.dart
@@ -41,7 +41,7 @@ void main() {
           // Clean up project directory (includes videos, stabilized, etc.)
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}

--- a/integration_test/video_playback_test.dart
+++ b/integration_test/video_playback_test.dart
@@ -43,7 +43,7 @@ void main() {
         try {
           final projectDir = await DirUtils.getProjectDirPath(testProjectId!);
           if (await Directory(projectDir).exists()) {
-            await Directory(projectDir).delete(recursive: true);
+            await deleteQuietly(Directory(projectDir));
           }
           await DB.instance.deleteProject(testProjectId!);
         } catch (_) {}


### PR DESCRIPTION
Three fixes, all of which exist because CI was reporting success it had not earned.

## 1. The tarball was never tested on a clean machine

The bundle smoke job installed `-dev` packages before launching:

```
libgtk-3-dev libgstreamer1.0-dev libmpv-dev libheif-dev libpng-dev libturbojpeg0-dev
```

Those drag in `libheif`, `libde265` and the GL stack transitively. That is a developer machine, not a user's, and it is why this job:

- **passed** for a bundle whose libraries could not resolve each other (#53)
- **passed again** for one that aborted on a missing `libGLESv2` (#55)

Both times the Debian job caught it immediately, because it installs only the package's declared dependencies. The tarball was the last published asset never verified on a clean system, and it is the one that **cannot declare dependencies of its own**, so users must supply them.

Now installs the runtime set the `.deb` declares. Package names verified against the noble archive; GTK and turbojpeg were renamed in the 64-bit `time_t` transition, so both spellings are accepted exactly as the `.deb` does with its `|` alternatives.

## 2. Cleanup could fail a passing test

Forty call sites deleted temp directories with no error handling. On Windows a spawned ffmpeg can still hold a handle when the test body ends, which fails with `errno 32` where POSIX unlinks happily:

```
Deletion failed, path = 'C:\...\Temp\drawtext_test'
(OS Error: The process cannot access the file because it is being used by another process, errno = 32)
  at integration_test/ffmpeg_binary_test.dart:213
```

That run reported `+31 ~45 -1` — every assertion passed and the housekeeping failed. It blocked #56. Several of these sites sit inside `finally` blocks, where a throwing cleanup also **masks the real test result**.

All 40 now route through a `deleteQuietly()` helper that retries briefly, then gives up and logs. A cleanup failure should never decide a test's outcome.

## 3. The Flathub manifest pinned three stale hashes

Only one was known going in. Verified all seven pins against their live sources and found three wrong:

| Pin | Was |
| --- | --- |
| bundle tarball | pointed at `agelapse-v2.7.0-pre`, a release that was never published, with a filename that never matched what the workflow produces |
| `.desktop` entry | stale from an earlier edit |
| `metainfo.xml` | stale as of this release, which added a `<release>` entry |

The tarball now points at the real published 2.7.0 asset, with its `sha256` verified by downloading the published file and comparing. Worth knowing: pinning `raw.githubusercontent.com/main/...` means the metainfo hash goes stale on **every** release that adds a `<release>` entry.

## Verification

`tool/check_format.sh` clean, `flutter analyze --fatal-infos .` clean, `flutter test` 1969 passed, both YAML files parse.

The real test of change 1 is the bundle smoke job in the next release run. If the tarball genuinely needs something the `.deb` does not declare, this is the change that will finally say so instead of hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)